### PR TITLE
Add Node.js 22.x engine specification for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "dftgh",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
This pull request introduces a new Node.js version requirement in the project configuration to ensure compatibility with Node.js 22.x.

- Project configuration:
  * Added an `engines` field to `package.json` to specify that the project requires Node.js version 22.x.